### PR TITLE
change java version to 1.8

### DIFF
--- a/foundation-common-base/pom.xml
+++ b/foundation-common-base/pom.xml
@@ -74,7 +74,7 @@
         <commons-version>1.0.2-1</commons-version>
         <guava-version>18.0</guava-version>
         <jetty-version>9.2.10.v20150310</jetty-version>
-        <javaVersion>1.7</javaVersion>
+        <javaVersion>1.8</javaVersion>
         <monitoring-api-version>1.0.3-1</monitoring-api-version>
         <monitoring-jmx-lib-version>1.0.3-1</monitoring-jmx-lib-version>
     </properties>


### PR DESCRIPTION
this is because the builds in cloudBees not successful see for example: https://vss-foundation.ci.cloudbees.com/job/queue-rabbitmq/181/console changing the java version should fix @yairogen please comment if you think there are side affects to this change.
@agrosmar 